### PR TITLE
Added $adobe_em6::params::download_aem_jar_timeout

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class adobe_em6 inherits adobe_em6::params {
     onlyif  => "test ! -f ${adobe_em6::params::aem_absolute_jar}",
     path    => ['/bin', '/usr/bin'],
     require => Package[ 'wget' ],
+    timeout => $adobe_em6::params::download_aem_jar_timeout,
   }
 
 }

--- a/manifests/instance/apply_updates.pp
+++ b/manifests/instance/apply_updates.pp
@@ -21,6 +21,7 @@
 
 define adobe_em6::instance::apply_updates (
   $filename     = UNSET,
+  $timeout      = $adobe_em6::params::download_aem_jar_timeout,
 ) {
 
   if ($filename !~ /.*\.zip/  or $filename == 'UNSET') {
@@ -52,6 +53,7 @@ define adobe_em6::instance::apply_updates (
     onlyif  => "test ! -f ${adobe_em6::params::dir_wget_cache}/${filename}",
     path    => ['/bin', '/usr/bin'],
     require => Package[ 'wget' ],
+    timeout => $timeout,
   }
 
   file { "${adobe_em6::params::dir_aem_install}/${instance_name}/crx-quickstart/install/${filename}":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,7 @@ class adobe_em6::params (
   $license_downloadid       = 'UNSET',
   $remote_url_for_files     = 'UNSET',
   $pkg_aem_jar_name         = 'AEM_6.0_Quickstart.jar',
+  $download_aem_jar_timeout = 1200,  # 20 minutes
 ) {
 
   # Setting Various base directories used by the installer


### PR DESCRIPTION
The default timeout (5 minutes) is too low in some circumstances,
so changing this to be configurable.
