### PR TITLE
Some Adobe em6 Cleanup

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,22 +24,26 @@ class adobe_em6 inherits adobe_em6::params {
 
 
   if $adobe_em6::params::remote_keystore_location != 'UNSET' {
-    exec { 'Check to see if the keystore is up-to-date, and update if not...':
-      command => "wget -N -P ${dir_aem_certs} ${adobe_em6::params::remote_keystore_location}",
-      logoutput => false,
-      timeout => $adobe_em6::params::exec_download_timeout,
-      user => 'root',
-      path => '/bin:/usr/bin'
+    exec { 'Updating keystore...':
+      command   =>  "mv aem_keystore.jks ${dir_aem_certs}/aem_keystore.jks; mv aem_keystore.jks.md5 ${dir_aem_certs}/aem_keystore.jks.md5",
+      logoutput =>  false,
+      timeout   =>  $adobe_em6::params::exec_download_timeout,
+      unless    =>  "wget -O 'aem_keystore.jks' ${adobe_em6::params::remote_keystore_location}; md5sum aem_keystore.jks > aem_keystore.jks.md5; md5sum -c --status --quiet aem_keystore.jks.md5 ${dir_aem_certs}/aem_keystore.jks.md5",
+      user      =>  'root',
+      cwd       =>  '/tmp',
+      path      =>  '/bin:/usr/bin'
     }
   }
 
   if $adobe_em6::params::remote_truststore_location != 'UNSET' {
-    exec { 'Check to see if the truststore is up-to-date, and update if not...':
-      command => "wget -N -P ${dir_aem_certs} ${adobe_em6::params::remote_truststore_location}",
-      logoutput => false,
-      timeout => $adobe_em6::params::exec_download_timeout,
-      user => 'root',
-      path => '/bin:/usr/bin'
+    exec { 'Updating truststore...':
+      command   =>  "mv aem_truststore.jks ${dir_aem_certs}/aem_truststore.jks; mv aem_truststore.jks.md5 ${dir_aem_certs}/aem_truststore.jks.md5",
+      logoutput =>  false,
+      timeout   =>  $adobe_em6::params::exec_download_timeout,
+      unless    =>  "wget -O 'aem_truststore.jks' ${adobe_em6::params::remote_truststore_location}; md5sum aem_truststore.jks > aem_truststore.jks.md5; md5sum -c --status --quiet aem_truststore.jks.md5 ${dir_aem_certs}/aem_truststore.jks.md5",
+      user      =>  'root',
+      cwd       =>  '/tmp',
+      path      =>  '/bin:/usr/bin'
     }
   }
 


### PR DESCRIPTION
- Only replacing truststores/keystores if a change has been made remotely.  This will clean up the reports. 
- Some logging about the AEM jar downloading
- Removing the the original AEM jar under /aem/(author|publish)/ as it's no longer needed after AEM is extracted.  Will save us 500MB of disk space.  
- Some consolidation and clean-up in instance.pp

@jscelza @cculb 
