### PR TITLE
Remove previous startup log after each AEM start

### DIFF
--- a/templates/start.erb
+++ b/templates/start.erb
@@ -67,16 +67,16 @@ if [ $CQ_USE_JAAS ]; then
 fi
 START_OPTS="${START_OPTS} -Dsling.properties=conf/sling.properties"
 
-STDOUTLOG="${CURR_DIR}/logs/stdout.log"
-if [ -e ${STDOUTLOG} ]
+STARTUPLOG="${CURR_DIR}/logs/startup.log"
+if [ -e ${STARTUPLOG} ]
 then
-        TIMESTAMP=`date +"%Y-%m-%d_%H-%M-%S"`
-        mv ${STDOUTLOG} ${STDOUTLOG}.${TIMESTAMP}
+		rm -f ${STARTUPLOG}
 fi
 
 (
   (
     java $CQ_JVM_OPTS -jar $CURR_DIR/$CQ_JARFILE $START_OPTS &
     echo $! > $CURR_DIR/conf/cq.pid
-  ) >> ${STDOUTLOG} 2>&1
+  ) >> ${STARTUPLOG} 2>&1
 ) &
+


### PR DESCRIPTION
@jscelza @cculb mind having a look?

Log rotation/cleanup is already handled by the dispatcher module in a fairly nice way, and logs managed by Sling can be configured to automatically delete after a threshold; however stdout have no such provisions.  Really, stdout (renamed to 'startup') is only useful every individual startup; so instead of keeping these files around, I figure we just delete them when they are no longer relevant.  This will prevent unnecessary disk fill up.  
