### PR TITLE
Provide functionality for puppet to manage offline compaction in an automated way. Provide utilties for manual intervention

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -89,6 +89,9 @@ define adobe_em6::instance (
   $aem_bundle_status_passwd   = hiera('adobe_em6::instance::aem_bundle_status_passwd', 'admin'),
   $instance_type              = hiera('adobe_em6::instance::instance_type', 'UNSET'),
   $instance_port              = hiera('adobe_em6::instance::instance_port', 'UNSET'),
+  $should_manage_compaction   = hiera('adobe_em6::instance::should_manage_compaction', 'false'),
+  $provision_compact_tool     = hiera('adobe_em6::instance::provision_compact_tool', 'false'),
+  $compact_disk_percent       = hiera('adobe_em6::instance::compact_disk_percent', '80'),
   $osgi_config_list           = hiera_hash('adobe_em6::instance::osgi_config_list', {} ),
   $replication_queues         = hiera_hash('adobe_em6::instance::replication_queues', {} ),
   $service_enable             = hiera('adobe_em6::instance::service_enable', 'true'),
@@ -168,11 +171,10 @@ define adobe_em6::instance (
   $aem_absolute_jar            = "${dir_instance_location}/${adobe_em6::params::pkg_aem_jar_name}"
   $exec_path                   = ['/bin', '/usr/bin', '/usr/local/bin', '/usr/java/latest/bin/' ]
 
-  notify { "Checking for AEM jar, and downloading if needed. This may take some time...":}
   exec { "Download AEM jar for ${title}":
     command   => "wget -q -N -P ${dir_instance_location} ${adobe_em6::params::remote_url_for_files}/${adobe_em6::params::pkg_aem_jar_name}",
     cwd       => $dir_instance_location,
-    logoutput => false,
+    logoutput => true,
     unless    => [ "test -d ${dir_instance_crx_quickstart}" ],
     path      =>  $exec_path,
     require   => [ Package[ 'wget' ], File[ $dir_instance_location ] ],
@@ -253,6 +255,37 @@ define adobe_em6::instance (
   file { "${dir_instance_crx_quickstart}/install":
     ensure  => 'directory',
     require => Exec[ "Unpack AEM jar for ${title}" ]
+  }
+
+  $compact_jar = "${adobe_em6::params::dir_tools}/offlineCompact.jar"
+
+  if ($should_manage_compaction == "true" or $provision_compact_tool == "true") {
+    $compact_tool_present = 'present'
+  }
+  else {
+    $compact_tool_present = 'absent'
+  }
+
+  file { $compact_jar:
+    ensure => $compact_tool_present,
+    require => Exec["Download compaction tool"]
+  }
+
+  exec { "Download compaction tool":
+    command     => "wget -O offlineCompact.jar ${adobe_em6::params::remote_url_for_files}/${adobe_em6::params::compact_jar_name}",
+    cwd         => "${adobe_em6::params::dir_tools}",
+    creates     => $compact_jar,
+    onlyif      => "test ${compact_tool_present} == 'present'",
+    logoutput   => false,
+    path        =>  $exec_path,
+    require     => [ Package[ 'wget' ] ],
+    timeout     => $adobe_em6::params::exec_download_timeout,
+    user        => $adobe_em6::params::aem_user
+  }
+  
+  file { "${adobe_em6::params::dir_tools}/aemUtils.sh":
+    ensure => present,
+    content => template('adobe_em6/aemUtils.erb')
   }
 
   ## TODO: This can be converted to an iteration feature starting in Puppet 3.2

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class adobe_em6::params (
   $license_downloadid         = 'UNSET',
   $remote_url_for_files       = 'UNSET',
   $pkg_aem_jar_name           = 'AEM_6.0_Quickstart.jar',
+  $compact_jar_name           = "oak-jcr-1.2.2.jar",
   $remote_truststore_location = 'UNSET',
 ) {
 

--- a/templates/aemUtils.erb
+++ b/templates/aemUtils.erb
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+REPOSITORY="<%= @dir_instance_crx_quickstart %>/repository/segmentstore"
+AEM_USER="<%= scope['::adobe_em6::params::aem_user'] %>"
+
+#Returns the total disk usage for the mount that contains the AEM repository. e.g "20" for 20% used
+function repositoryDiskUsage() {
+    df -h ${REPOSITORY} | grep -Po "([0-9]{1,3})%" | tr -d %
+}
+
+function aboveDiskUsageThreshold() {
+    THRESHOLD="<%= @compact_disk_percent %>"
+    if [ $(repositoryDiskUsage) -ge ${THRESHOLD} ]; then
+        echo true
+    else
+        echo false
+    fi
+}
+
+function runOfflineCompaction() {
+    if [ $(whoami) != "root" ] && [ $(whoami) != ${AEM_USER} ]; then
+        log "You must be root or ${AEM_USER}"
+        exit 1
+    fi
+    if [ -f /var/lock/subsys/aem_<%= @title %> ]; then
+        log "To run offline compaction, AEM must be shutdown."
+        exit 1
+    fi
+    if [ -f "<%= @compact_jar %>" ]; then
+        chkpoint_cmd="java -Dtar.memoryMapped=true -jar <%= @compact_jar %> checkpoints ${REPOSITORY} rm-unreferenced"
+        compact_cmd="java -Dtar.memoryMapped=true -jar <%= @compact_jar %> compact ${REPOSITORY}"
+        if [ $(whoami) == "root" ]; then
+          chkpoint_cmd="sudo -u ${AEM_USER} ${chkpoint_cmd}"
+          compact_cmd="sudo -u ${AEM_USER} ${compact_cmd}"
+        fi
+        log "Performing TAR compaction.."
+        log "Deleting unreferenced checkpoints.."
+        eval $chkpoint_cmd
+        log "Compacting segment store.."
+        eval $compact_cmd
+    else
+        log "Offline compaction not running, because compaction software is not provisioned"
+    fi
+}
+
+function log() {
+    echo $1
+    logger $1
+}
+
+case $1 in
+    repositoryDiskUsage) repositoryDiskUsage ;;
+    aboveDiskUsageThreshold) aboveDiskUsageThreshold ;;
+    runOfflineCompaction) runOfflineCompaction ;;
+esac

--- a/templates/aem_type.erb
+++ b/templates/aem_type.erb
@@ -12,6 +12,9 @@
 # Source networking configuration.
 . /etc/sysconfig/network
 
+# Source AEM utilities
+. <%= scope['::adobe_em6::params::dir_tools'] %>/aemUtils.sh
+
 # Check that networking is up.
 [ ${NETWORKING} = "no" ] && exit 1
 
@@ -20,10 +23,21 @@ INSTANCENAME="<%= @instance_name %>"
 PROG="AEM ${INSTANCENAME} instance."
 STARTUPDIR="<%= scope['::adobe_em6::params::dir_aem_install'] %>/${INSTANCENAME}/crx-quickstart"
 AEMUSER="<%= scope['::adobe_em6::params::aem_user'] %>"
+MANAGE_COMPACTION="<%= @should_manage_compaction %>"
 LOCK="/var/lock/subsys/aem_${INSTANCENAME}"
 
 start() {
+  #Make sure more than one AEM process isn't started
   [ -f "${LOCK}" ] && exit 0
+  if [ ${MANAGE_COMPACTION} == "true" ]; then
+    #See aemUtils for these function definitions
+    if [ $(aboveDiskUsageThreshold) == "true" ]; then
+      log "Your machine has managed compaction set, and has crossed the set disk threshold"
+      log "JCR compaction will be run now to ensure system stability. AEM will start after this process is complete."
+      runOfflineCompaction
+    fi
+  fi
+  #Create a lock, so that when the OS changes run levels, the AEM process is killed correctly (and stop called below)
   touch "${LOCK}"
   log "$(date) - Starting: ${PROG}"
   su - ${AEMUSER} -c "${STARTUPDIR}/bin/start"
@@ -33,8 +47,7 @@ stop() {
   log "$(date) - Shutting down: ${PROG}"
   su - ${AEMUSER} -c "${STARTUPDIR}/bin/stop"
   wait
-  #Let things settle a bit
-  sleep 5
+  #When AEM is finished shutting down, only then do we let OS shutdown continue
   rm -rf "${LOCK}"
 }
 


### PR DESCRIPTION
- Functionality for module to provision AEM compaction tool (adobe_em6::instance::provision_compact_tool)
- Functionality for module to enable compaction management feature (adobe_em6::instance::should_manage_compaction)
  - Provisions compaction tool
  - Automatically runs compaction before start-up if disk usage is above a set threshold (adobe_em6::instance::compact_disk_percent)

Misc : 
- Remove download AEM jar notification to silence change reporting.
- Remove unnecessary, paranoid sleep in init script 
