### PR TITLE
Updating syntax for puppet parser 4 aka v2015.3.2

### DIFF
--- a/manifests/archive/tools_setup.pp
+++ b/manifests/archive/tools_setup.pp
@@ -23,7 +23,7 @@ class adobe_em6::tools_setup {
     path    => "${adobe_em::dir_tools}/consistencyCheck.sh",
     content => template('adobe_em/consistencyCheck.sh.erb'),
     mode    => '0744',
-    require => [ File[ 'create aem tools log directory' ], File[ 'create aem tools directory' ] ],
+    require =>[File['create aem tools log directory'], File['create aem tools directory']],
   }
 
   file { 'create aemGarbageCollection.sh' :
@@ -31,7 +31,7 @@ class adobe_em6::tools_setup {
     path    => "${adobe_em::dir_tools}/aemGarbageCollection.sh",
     content => template('adobe_em/aemGarbageCollection.sh.erb'),
     mode    => '0744',
-    require => [ File[ 'create aem tools log directory' ], File[ 'create aem tools directory' ] ],
+    require =>[File['create aem tools log directory'], File['create aem tools directory']],
   }
 
   cron { "cron for ${cms_type} consistencyCheck.sh" :

--- a/manifests/instance/apply_osgi_config.pp
+++ b/manifests/instance/apply_osgi_config.pp
@@ -58,92 +58,92 @@ define adobe_em6::instance::apply_osgi_config (
 
   ensure_resource('file', $tmp_osgi_dir, {
     'ensure' => 'directory',
-    require => File[ $adobe_em6::params::dir_aem_install ],
+    require => File[$adobe_em6::params::dir_aem_install],
   })
 
   file { "${tmp_osgi_dir}/${title}":
     ensure  => 'directory',
-    require => File[ $tmp_osgi_dir ],
+    require => File[$tmp_osgi_dir],
   }
 
   ###  Creating package Metadata directory
   file { "${tmp_osgi_dir}/${title}/META-INF":
     ensure  => 'directory',
-    require => File[ "${tmp_osgi_dir}/${title}" ],
+    require => File["${tmp_osgi_dir}/${title}"],
   }
 
   file { "${tmp_osgi_dir}/${title}/META-INF/vault":
     ensure  => 'directory',
-    require => File[ "${tmp_osgi_dir}/${title}/META-INF" ],
+    require => File["${tmp_osgi_dir}/${title}/META-INF"],
   }
 
   file { "${tmp_osgi_dir}/${title}/META-INF/vault/definition":
     ensure  => 'directory',
-    require => File[ "${tmp_osgi_dir}/${title}/META-INF" ],
+    require => File["${tmp_osgi_dir}/${title}/META-INF"],
   }
 
   ### Creating content directories
   file { "${tmp_osgi_dir}/${title}/jcr_root":
     ensure  => 'directory',
-    require => File[ "${tmp_osgi_dir}/${title}" ],
+    require => File["${tmp_osgi_dir}/${title}"],
   }
 
   file { "${tmp_osgi_dir}/${title}/jcr_root/apps":
     ensure  => 'directory',
-    require => File[ "${tmp_osgi_dir}/${title}/jcr_root" ],
+    require => File["${tmp_osgi_dir}/${title}/jcr_root"],
   }
 
   file { "${tmp_osgi_dir}/${title}/jcr_root/apps/system":
     ensure  => 'directory',
-    require => File[ "${tmp_osgi_dir}/${title}/jcr_root/apps" ],
+    require => File["${tmp_osgi_dir}/${title}/jcr_root/apps"],
   }
 
   file { "${tmp_osgi_dir}/${title}/jcr_root/apps/system/config":
     ensure  => 'directory',
-    require => File[ "${tmp_osgi_dir}/${title}/jcr_root/apps/system" ],
+    require => File["${tmp_osgi_dir}/${title}/jcr_root/apps/system"],
   }
 
   ### Creating the files for package
   file { "${tmp_osgi_dir}/${title}/jcr_root/apps/system/config/${title}.xml":
     ensure  => 'present',
     content => template('adobe_em6/osgi_config/osgi.xml.erb'),
-    require => File[ "${tmp_osgi_dir}/${title}/jcr_root/apps/system/config" ]
+    require => File["${tmp_osgi_dir}/${title}/jcr_root/apps/system/config"]
   }
 
   file { "${tmp_osgi_dir}/${title}/META-INF/vault/config.xml":
     ensure  => 'present',
     content => template('adobe_em6/osgi_config/config.xml.erb'),
-    require => File[ "${tmp_osgi_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_osgi_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_osgi_dir}/${title}/META-INF/vault/filter.xml":
     ensure  => 'present',
     content => template('adobe_em6/osgi_config/filter.xml.erb'),
-    require => File[ "${tmp_osgi_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_osgi_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_osgi_dir}/${title}/META-INF/vault/nodetypes.cnd":
     ensure  => 'present',
     content => template('adobe_em6/osgi_config/nodetypes.cnd.erb'),
-    require => File[ "${tmp_osgi_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_osgi_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_osgi_dir}/${title}/META-INF/vault/properties.xml":
     ensure  => 'present',
     content => template('adobe_em6/osgi_config/properties.xml.erb'),
-    require => File[ "${tmp_osgi_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_osgi_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_osgi_dir}/${title}/META-INF/vault/settings.xml":
     ensure  => 'present',
     content => template('adobe_em6/replication/settings.xml.erb'),
-    require => File[ "${tmp_osgi_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_osgi_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_osgi_dir}/${title}/META-INF/vault/definition/.content.xml":
     ensure  => 'present',
     content => template('adobe_em6/osgi_config/definition_content.xml.erb'),
-    require => File[ "${tmp_osgi_dir}/${title}/META-INF/vault/definition" ],
+    require => File["${tmp_osgi_dir}/${title}/META-INF/vault/definition"],
   }
 
   $package_zip_install_folder = "${adobe_em6::params::dir_aem_install}/${instance_name}/crx-quickstart/install/"
@@ -151,13 +151,13 @@ define adobe_em6::instance::apply_osgi_config (
 
   ### Create package to be used to install into instance
   ###
-  $requiredFiles = [  File[ "${tmp_osgi_dir}/${title}/META-INF/vault/definition/.content.xml" ],
-                      File[ "${tmp_osgi_dir}/${title}/META-INF/vault/settings.xml" ],
-                      File[ "${tmp_osgi_dir}/${title}/META-INF/vault/properties.xml" ],
-                      File[ "${tmp_osgi_dir}/${title}/META-INF/vault/nodetypes.cnd" ],
-                      File[ "${tmp_osgi_dir}/${title}/META-INF/vault/filter.xml" ],
-                      File[ "${tmp_osgi_dir}/${title}/META-INF/vault/config.xml" ],
-                      File[ "${tmp_osgi_dir}/${title}/jcr_root/apps/system/config/${title}.xml" ] ]
+  $requiredFiles =[ File["${tmp_osgi_dir}/${title}/META-INF/vault/definition/.content.xml"],
+                      File["${tmp_osgi_dir}/${title}/META-INF/vault/settings.xml"],
+                      File["${tmp_osgi_dir}/${title}/META-INF/vault/properties.xml"],
+                      File["${tmp_osgi_dir}/${title}/META-INF/vault/nodetypes.cnd"],
+                      File["${tmp_osgi_dir}/${title}/META-INF/vault/filter.xml"],
+                      File["${tmp_osgi_dir}/${title}/META-INF/vault/config.xml"],
+                      File["${tmp_osgi_dir}/${title}/jcr_root/apps/system/config/${title}.xml"]]
 
   if($instance_name == 'publish') {
     $port = "4503"
@@ -171,7 +171,7 @@ define adobe_em6::instance::apply_osgi_config (
     command => "set -e ; ${adobe_em6::params::dir_tools}/aem_bundle_status.rb -a http://localhost:${port}/system/console/bundles.json -u ${aem_bundle_status_user} -p ${aem_bundle_status_passwd}; /bin/rm -rf *.zip ; /usr/bin/zip -r ${package_zip_file} * ; /bin/mv -f ${package_zip_file} ${package_zip_install_folder}",
     provider => 'shell',
     cwd     => "${tmp_osgi_dir}/${title}",
-    subscribe => File[ "${tmp_osgi_dir}/${title}/jcr_root/apps/system/config/${title}.xml" ],
+    subscribe => File["${tmp_osgi_dir}/${title}/jcr_root/apps/system/config/${title}.xml"],
     require => $requiredFiles,
     refreshonly => true,
     tries => 40,

--- a/manifests/instance/apply_packages.pp
+++ b/manifests/instance/apply_packages.pp
@@ -79,7 +79,7 @@ define adobe_em6::instance::apply_packages (
     onlyif  => "test ! -f ${$hotfix_file_cache}",
     path    => ['/bin', '/usr/bin'],
     timeout => $adobe_em6::params::exec_download_timeout,
-    require => Package[ 'wget' ],
+    require => Package['wget'],
   }
 
   if($instance_type == 'publish') {
@@ -100,7 +100,7 @@ define adobe_em6::instance::apply_packages (
     user    => $adobe_em6::params::aem_user,
     unless  => "/usr/bin/test -f ${hotfix_file_install}",
     path    => [ '/bin', '/usr/bin' ],
-    require => Exec [ "download_${title}_package" ],
+    require => Exec["download_${title}_package"],
     tries => 40,
     try_sleep => 15
   }

--- a/manifests/instance/replication_queues.pp
+++ b/manifests/instance/replication_queues.pp
@@ -72,101 +72,101 @@ define adobe_em6::instance::replication_queues (
 
   ensure_resource('file', $tmp_queue_dir, {
     ensure => 'directory',
-    require => File[ $adobe_em6::params::dir_aem_install ],
+    require => File[$adobe_em6::params::dir_aem_install],
   })
 
   # TLD queue staging directory used to build content packages, based on queue name
   file { "${tmp_queue_dir}/${title}":
     ensure  => 'directory',
-    require => File[ $tmp_queue_dir ],
+    require => File[$tmp_queue_dir],
   }
 
   ###  Creating package Metadata directory
   file { "${tmp_queue_dir}/${title}/META-INF":
     ensure  => 'directory',
-    require => File[ "$tmp_queue_dir/${title}" ],
+    require => File["$tmp_queue_dir/${title}"],
   }
 
   file { "${tmp_queue_dir}/${title}/META-INF/vault":
     ensure  => 'directory',
-    require => File[ "$tmp_queue_dir/${title}/META-INF" ],
+    require => File["$tmp_queue_dir/${title}/META-INF"],
   }
 
   file { "${tmp_queue_dir}/${title}/META-INF/vault/definition":
     ensure  => 'directory',
-    require => File[ "$tmp_queue_dir/${title}/META-INF" ],
+    require => File["$tmp_queue_dir/${title}/META-INF"],
   }
 
   ###  Creating content directories
   file { "${tmp_queue_dir}/${title}/jcr_root":
     ensure  => 'directory',
-    require => File[ "$tmp_queue_dir/${title}" ],
+    require => File["$tmp_queue_dir/${title}"],
   }
 
   file { "${tmp_queue_dir}/${title}/jcr_root/etc":
     ensure  => 'directory',
-    require => File[ "${tmp_queue_dir}/${title}/jcr_root" ],
+    require => File["${tmp_queue_dir}/${title}/jcr_root"],
   }
 
   file { "${tmp_queue_dir}/${title}/jcr_root/etc/replication":
     ensure  => 'directory',
-    require => File[ "${tmp_queue_dir}/${title}/jcr_root/etc" ],
+    require => File["${tmp_queue_dir}/${title}/jcr_root/etc"],
   }
 
   file { "${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}":
     ensure  => 'directory',
-    require => File[ "${tmp_queue_dir}/${title}/jcr_root/etc/replication" ],
+    require => File["${tmp_queue_dir}/${title}/jcr_root/etc/replication"],
   }
 
   file { "${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}/${title}":
     ensure  => 'directory',
-    require => File[ "${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}" ],
+    require => File["${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}"],
   }
 
   ### Creating the files for package
   file { "${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}/${title}/.content.xml":
     ensure  => 'present',
     content => template('adobe_em6/replication/replication_content.xml.erb'),
-    require => File[ "${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}/${title}" ],
+    require => File["${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}/${title}"],
   }
 
   file { "${tmp_queue_dir}/${title}/META-INF/vault/config.xml":
     ensure  => 'present',
     content => template('adobe_em6/replication/config.xml.erb'),
-    require => File[ "${tmp_queue_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_queue_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_queue_dir}/${title}/META-INF/vault/filter.xml":
     ensure  => 'present',
     content => template('adobe_em6/replication/filter.xml.erb'),
-    require => File[ "${tmp_queue_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_queue_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_queue_dir}/${title}/META-INF/vault/nodetypes.cnd":
     ensure  => 'present',
     content => template('adobe_em6/replication/nodetypes.cnd.erb'),
-    require => File[ "${tmp_queue_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_queue_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_queue_dir}/${title}/META-INF/vault/properties.xml":
     ensure  => 'present',
     content => template('adobe_em6/replication/properties.xml.erb'),
-    require => File[ "${tmp_queue_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_queue_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_queue_dir}/${title}/META-INF/vault/settings.xml":
     ensure  => 'present',
     content => template('adobe_em6/replication/settings.xml.erb'),
-    require => File[ "${tmp_queue_dir}/${title}/META-INF/vault" ],
+    require => File["${tmp_queue_dir}/${title}/META-INF/vault"],
   }
 
   file { "${tmp_queue_dir}/${title}/META-INF/vault/definition/.content.xml":
     ensure  => 'present',
     content => template('adobe_em6/replication/definition_content.xml.erb'),
-    require => File[ "${tmp_queue_dir}/${title}/META-INF/vault/definition" ],
+    require => File["${tmp_queue_dir}/${title}/META-INF/vault/definition"],
   }
 
-  $requiredFiles = [ File[ "${tmp_queue_dir}/${title}/META-INF/vault/definition/.content.xml" ],
+  $requiredFiles = [File["${tmp_queue_dir}/${title}/META-INF/vault/definition/.content.xml"],
     File[ "${tmp_queue_dir}/${title}/META-INF/vault/settings.xml" ],
     File[ "${tmp_queue_dir}/${title}/META-INF/vault/properties.xml" ],
     File[ "${tmp_queue_dir}/${title}/META-INF/vault/nodetypes.cnd" ],
@@ -192,7 +192,7 @@ define adobe_em6::instance::replication_queues (
     provider => "shell",
     cwd     => "${tmp_queue_dir}/${title}",
     user    => $adobe_em6::params::aem_user,
-    subscribe => File[ "${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}/${title}/.content.xml" ],
+    subscribe => File["${tmp_queue_dir}/${title}/jcr_root/etc/replication/agents.${instance_type}/${title}/.content.xml"],
     require => $requiredFiles,
     refreshonly => true,
     path    => ['/bin', '/usr/bin'],

--- a/manifests/instance/service.pp
+++ b/manifests/instance/service.pp
@@ -64,7 +64,7 @@ define adobe_em6::instance::service (
       hasrestart  => true,
       hasstatus   => true,
       name        => "aem_${instance_name}",
-      require     => [ File["/etc/init.d/aem_${instance_name}"],
+      require     => [File["/etc/init.d/aem_${instance_name}"],
         File["${adobe_em6::params::dir_aem_install}/${instance_name}/crx-quickstart/bin/start"],
         File["${adobe_em6::params::dir_aem_install}/${instance_name}/license.properties"]
       ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,7 @@ class adobe_em6::params (
   $license_downloadid         = 'UNSET',
   $remote_url_for_files       = 'UNSET',
   $pkg_aem_jar_name           = 'AEM_6.0_Quickstart.jar',
+  $compact_jar_name           = "oak-jcr-1.2.2.jar",
   $remote_truststore_location = 'UNSET',
 ) {
 

--- a/manifests/pre_install_directory.pp
+++ b/manifests/pre_install_directory.pp
@@ -37,7 +37,7 @@ class adobe_em6::pre_install_directory {
       ensure  => directory,
       owner   => 'root',
       group   => 'root',
-      require => File[ $adobe_em6::params::dir_base ]
+      require => File[$adobe_em6::params::dir_base]
     }
   }
 
@@ -46,7 +46,7 @@ class adobe_em6::pre_install_directory {
       ensure  => directory,
       owner   => 'root',
       group   => 'root',
-      require => File[ $adobe_em6::params::dir_base ]
+      require => File[$adobe_em6::params::dir_base]
     }
   }
 
@@ -55,36 +55,36 @@ class adobe_em6::pre_install_directory {
       ensure  => directory,
       owner   => 'root',
       group   => 'root',
-      require => File[ $adobe_em6::params::dir_base ]
+      require => File[$adobe_em6::params::dir_base]
     }
   }
 
   if ! defined(File[$adobe_em6::params::dir_aem_certs]) {
     file { $adobe_em6::params::dir_aem_certs:
       ensure  => 'directory',
-      require => File[ $adobe_em6::params::dir_base ],
+      require => File[$adobe_em6::params::dir_base],
     }
   }
   ######  AEM specific base directories
 
   file { $adobe_em6::params::dir_aem_install:
     ensure  => 'directory',
-    require => File[ $adobe_em6::params::dir_base_apps ],
+    require => File[$adobe_em6::params::dir_base_apps],
   }
 
   file { $adobe_em6::params::dir_aem_log:
     ensure  => 'directory',
-    require => File[ $adobe_em6::params::dir_base_logs ],
+    require => File[$adobe_em6::params::dir_base_logs],
   }
 
   file { $adobe_em6::params::dir_tools:
     ensure  => 'directory',
-    require => File[ $adobe_em6::params::dir_base_tools ],
+    require => File[$adobe_em6::params::dir_base_tools],
   }
 
   file { $adobe_em6::params::dir_tools_log:
     ensure  => 'directory',
-    require => File[ $adobe_em6::params::dir_base_logs ],
+    require => File[$adobe_em6::params::dir_base_logs],
   }
 
 }

--- a/manifests/tools.pp
+++ b/manifests/tools.pp
@@ -21,19 +21,19 @@ class adobe_em6::tools {
 
   package { 'rubygems' :
     ensure => '1.3.7-5.el6',
-    require => Package[ 'ruby' ]
+    require => Package['ruby']
   }
 
   package { 'json_pure' :
     provider => 'gem',
     ensure => "1.8.2",
-    require => Package[ 'ruby' ]
+    require => Package['ruby']
   }
 
   file { "${adobe_em6::params::dir_tools}/aem_bundle_status.rb":
     ensure  => 'present',
     source  => 'puppet:///modules/adobe_em6/aem_bundle_status.rb',
-    require => [ File[ $adobe_em6::params::dir_tools ], Package[ 'ruby' ], Package[ 'json_pure' ] ]
+    require => [File[$adobe_em6::params::dir_tools], Package['ruby'], Package['json_pure']]
   }
 
 }

--- a/templates/aemUtils.erb
+++ b/templates/aemUtils.erb
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+REPOSITORY="<%= @dir_instance_crx_quickstart %>/repository/segmentstore"
+AEM_USER="<%= scope['::adobe_em6::params::aem_user'] %>"
+
+#Returns the total disk usage for the mount that contains the AEM repository. e.g "20" for 20% used
+function repositoryDiskUsage() {
+    df -h ${REPOSITORY} | grep -Po "([0-9]{1,3})%" | tr -d %
+}
+
+function aboveDiskUsageThreshold() {
+    THRESHOLD="<%= @compact_disk_percent %>"
+    if [ $(repositoryDiskUsage) -ge ${THRESHOLD} ]; then
+        echo true
+    else
+        echo false
+    fi
+}
+
+function runOfflineCompaction() {
+    if [ $(whoami) != "root" ] && [ $(whoami) != ${AEM_USER} ]; then
+        log "You must be root or ${AEM_USER}"
+        exit 1
+    fi
+    if [ -f /var/lock/subsys/aem_<%= @title %> ]; then
+        log "To run offline compaction, AEM must be shutdown."
+        exit 1
+    fi
+    if [ -f "<%= @compact_jar %>" ]; then
+        chkpoint_cmd="java -Dtar.memoryMapped=true -jar <%= @compact_jar %> checkpoints ${REPOSITORY} rm-unreferenced"
+        compact_cmd="java -Dtar.memoryMapped=true -jar <%= @compact_jar %> compact ${REPOSITORY}"
+        if [ $(whoami) == "root" ]; then
+          chkpoint_cmd="sudo -u ${AEM_USER} ${chkpoint_cmd}"
+          compact_cmd="sudo -u ${AEM_USER} ${compact_cmd}"
+        fi
+        log "Performing TAR compaction.."
+        log "Deleting unreferenced checkpoints.."
+        eval $chkpoint_cmd
+        log "Compacting segment store.."
+        eval $compact_cmd
+    else
+        log "Offline compaction not running, because compaction software is not provisioned"
+    fi
+}
+
+function log() {
+    echo $1
+    logger $1
+}
+
+case $1 in
+    repositoryDiskUsage) repositoryDiskUsage ;;
+    aboveDiskUsageThreshold) aboveDiskUsageThreshold ;;
+    runOfflineCompaction) runOfflineCompaction ;;
+esac

--- a/templates/aem_type.erb
+++ b/templates/aem_type.erb
@@ -12,6 +12,9 @@
 # Source networking configuration.
 . /etc/sysconfig/network
 
+# Source AEM utilities
+. <%= scope['::adobe_em6::params::dir_tools'] %>/aemUtils.sh
+
 # Check that networking is up.
 [ ${NETWORKING} = "no" ] && exit 1
 
@@ -20,10 +23,21 @@ INSTANCENAME="<%= @instance_name %>"
 PROG="AEM ${INSTANCENAME} instance."
 STARTUPDIR="<%= scope['::adobe_em6::params::dir_aem_install'] %>/${INSTANCENAME}/crx-quickstart"
 AEMUSER="<%= scope['::adobe_em6::params::aem_user'] %>"
+MANAGE_COMPACTION="<%= @should_manage_compaction %>"
 LOCK="/var/lock/subsys/aem_${INSTANCENAME}"
 
 start() {
+  #Make sure more than one AEM process isn't started
   [ -f "${LOCK}" ] && exit 0
+  if [ ${MANAGE_COMPACTION} == "true" ]; then
+    #See aemUtils for these function definitions
+    if [ $(aboveDiskUsageThreshold) == "true" ]; then
+      log "Your machine has managed compaction set, and has crossed the set disk threshold"
+      log "JCR compaction will be run now to ensure system stability. AEM will start after this process is complete."
+      runOfflineCompaction
+    fi
+  fi
+  #Create a lock, so that when the OS changes run levels, the AEM process is killed correctly (and stop called below)
   touch "${LOCK}"
   log "$(date) - Starting: ${PROG}"
   su - ${AEMUSER} -c "${STARTUPDIR}/bin/start"
@@ -33,8 +47,7 @@ stop() {
   log "$(date) - Shutting down: ${PROG}"
   su - ${AEMUSER} -c "${STARTUPDIR}/bin/stop"
   wait
-  #Let things settle a bit
-  sleep 5
+  #When AEM is finished shutting down, only then do we let OS shutdown continue
   rm -rf "${LOCK}"
 }
 


### PR DESCRIPTION
Syntax changes for puppet version v2015.3.2
Backward compatible
Spaces are not allowed in certain areas now.  I ran a script to munch spaces, so it picked up a few misc spaces that didn't matter.

@jdigger 
@jscelza 
@jbornemann 
@sagarsane 
@cculb
